### PR TITLE
New features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: publish pab
+name: CI
 on:
   push:
     branches:
       - master
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,11 +19,29 @@ jobs:
           poetry install
       - name: run test
         run: poetry run pytest -x
-      - name: publish
-        # use twine for now as poetry hasn't released --skip-existing option yet
-        # run: poetry publish --build --username $PYPI_USER --password $PYPI_PWD
+      - name: build wheels
+        run: poetry build
+      - name: upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+  release:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/master') || startswith(github.ref, 'refs/heads/dev-ci')"
+    needs: [build]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+      - name: pypi publish
         run: |
-          poetry build
+          pip install twine
           twine upload --skip-existing dist/* -u $PYPI_USER -p $PYPI_PWD
         env:
           PYPI_USER: __token__

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,8 @@
             "args": [
                 "-svv",
                 "-k",
-                "remote_diff"
+                "test_install_dependency"
             ],
-            "justMyCode": true
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,7 @@
             "module": "pytest",
             "args": [
                 "-svv",
-                "-k",
-                "test_install_dependency"
+                "tests/test_diff.py::test_remote_diff"
             ],
         }
     ]

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ pbt list [-d]
 2. **Create virtual environment of a package and install its dependencies**
 
 ```bash
-pbt install [-e] [-d] [-v] [-p <package>]
+pbt install [-d] [-v] [-p <package>]
 ```
 
-- `-e`: install the package, and its local (inter-) dependencies in editable mode
 - `-d`: also install dev-dependencies of the package
 - `-v`: verbose
 - `-p`: specify the package we want to build, if empty build all packages.
@@ -63,14 +62,6 @@ pbt clean [-p <package>]
 ```
 
 - `-p`: specify the package we want to build, if empty build all packages.
-
-5. **Create setup.py**
-
-Generate a `setup.py` file that can be used to manually install in editable mode as poetry does not provide it out of the box at the time of writing. This is usually used for debugging. Note that if you install `pip install -e .`, you need to rename the file `pyproject.toml` temporary so that `pip` will use `setup.py` instead of `pyproject.toml`.
-
-```bash
-pbt create-setuppy -p <project>
-```
 
 6. **Git clone a multi-repository project**
 

--- a/pbt/__main__.py
+++ b/pbt/__main__.py
@@ -3,7 +3,7 @@ import importlib.metadata
 import click
 from loguru import logger
 
-from pbt.console.pbt import install, clean, update, publish, create_setuppy, list
+from pbt.console.pbt import install, clean, update, publish, list
 from pbt.console.git import git
 from pbt.package.registry.pypi import PyPI
 
@@ -34,7 +34,6 @@ cli.add_command(install)
 cli.add_command(clean)
 cli.add_command(publish)
 cli.add_command(update)
-cli.add_command(create_setuppy)
 cli.add_command(git)
 cli.add_command(list)
 

--- a/pbt/config.py
+++ b/pbt/config.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Set, Union
+from typing import List, Optional, Set, Union
 from loguru import logger
 
 import orjson
@@ -15,6 +15,7 @@ PBT_LOCK_FILE_NAME = "pbt.lock"
 
 @dataclass
 class PBTConfig:
+    # current working directory
     cwd: Path
     # directory
     cache_dir: Path
@@ -22,6 +23,8 @@ class PBTConfig:
     ignore_packages: Set[str] = field(default_factory=set)
     # packages that do not contain any code with sole purpose for installing dependencies or creating working environment
     phantom_packages: Set[str] = field(default_factory=set)
+    # skip building these local packages (i.e., rely on the package registry to find an installable version)
+    skip_building_packages: Set[str] = field(default_factory=set)
     # use pre-built binaries for the package if available
     use_prebuilt_binaries: Set[str] = field(default_factory=set)
     # directory to store the built artifacts for release (relative to each package's location)
@@ -78,6 +81,7 @@ class PBTConfig:
             cache_dir=cache_dir,
             ignore_packages=set(cfg.get("ignore_packages", [])),
             phantom_packages=set(cfg.get("phantom_packages", [])),
+            skip_building_packages=set(cfg.get("skip_building_packages", [])),
             use_prebuilt_binaries=set(cfg.get("use_prebuilt_binaries", True)),
             distribution_dir=Path(cfg.get("distribution_dir", "./dist")),
             python_virtualenvs_path=cfg.get("python_virtualenvs_path", "./.venv"),

--- a/pbt/config.py
+++ b/pbt/config.py
@@ -23,9 +23,7 @@ class PBTConfig:
     ignore_packages: Set[str] = field(default_factory=set)
     # packages that do not contain any code with sole purpose for installing dependencies or creating working environment
     phantom_packages: Set[str] = field(default_factory=set)
-    # skip building these local packages (i.e., rely on the package registry to find an installable version)
-    skip_building_packages: Set[str] = field(default_factory=set)
-    # use pre-built binaries for the package if available
+    # use pre-built binaries for the package if available (i.e., rely on the package registry to find an installable version)
     use_prebuilt_binaries: Set[str] = field(default_factory=set)
     # directory to store the built artifacts for release (relative to each package's location)
     distribution_dir: Path = Path("./dist")
@@ -76,16 +74,22 @@ class PBTConfig:
             cfg = {}
 
         logger.info("Root directory: {}", cwd)
+
+        if "python_path" not in cfg:
+            # try use python_path from the environment variable: `PBT_PYTHON`
+            python_path = os.environ.get("PBT_PYTHON", None)
+        else:
+            python_path = cfg["python_path"]
+
         return PBTConfig(
             cwd=cwd,
             cache_dir=cache_dir,
             ignore_packages=set(cfg.get("ignore_packages", [])),
             phantom_packages=set(cfg.get("phantom_packages", [])),
-            skip_building_packages=set(cfg.get("skip_building_packages", [])),
             use_prebuilt_binaries=set(cfg.get("use_prebuilt_binaries", True)),
             distribution_dir=Path(cfg.get("distribution_dir", "./dist")),
             python_virtualenvs_path=cfg.get("python_virtualenvs_path", "./.venv"),
-            python_path=Path(cfg.get("python_path", None)),
+            python_path=Path(python_path) if python_path is not None else None,
         )
 
     def pkg_cache_dir(self, pkg: Package) -> Path:

--- a/pbt/console/git.py
+++ b/pbt/console/git.py
@@ -14,7 +14,7 @@ from pbt.vcs.git import Git
     help="Specify the multi-repository that we are working with. e.g., https://github.com/binh-vu/pbt",
 )
 @click.option("--cwd", default=".", help="Override current working directory")
-@click.argument("subcommand")
+@click.argument("subcommand", type=click.Choice(["clone", "update", "push", "snapshot"]), help="Subcommand to run")
 def git(repo: str, cwd: str, subcommand: Literal["snapshot"]):
     """Execute Git commands in a super-project"""
     cwd = os.path.abspath(cwd)

--- a/pbt/console/pbt.py
+++ b/pbt/console/pbt.py
@@ -180,15 +180,11 @@ def publish(package: List[str], cwd: str = ".", verbose: bool = False):
     is_flag=True,
     help="increase verbosity",
 )
-def create_setuppy(package: List[str], cwd: str = ".", verbose: bool = False):
-    """Create setup.py file of a python package"""
+def build(package: List[str], cwd: str = ".", verbose: bool = False):
+    """Build packages"""
     pl, cfg, pkgs = init(cwd, package, verbose)
-
     with build_cache():
         for pkg_name in pkgs:
             pkg = pl.pkgs[pkg_name]
             manager = pl.managers[pkg.type]
-            assert isinstance(
-                manager, Poetry
-            ), "Only create setup.py for Poetry packages"
-            manager.create_setup_py(pkg)
+            manager.build(pkg)

--- a/pbt/console/pbt.py
+++ b/pbt/console/pbt.py
@@ -83,12 +83,6 @@ def list(dev: bool = False, cwd: str = ".", verbose: bool = False):
     is_flag=True,
     help="Whether to install dev-dependencies as well",
 )
-@click.option(
-    "-e",
-    "--editable",
-    is_flag=True,
-    help="Whether to install the package and its local dependencies in editable mode",
-)
 @click.option("--cwd", default=".", help="Override current working directory")
 @click.option(
     "-v",
@@ -99,14 +93,13 @@ def list(dev: bool = False, cwd: str = ".", verbose: bool = False):
 def install(
     package: List[str],
     dev: bool = False,
-    editable: bool = False,
     cwd: str = ".",
     verbose: bool = False,
 ):
     """Make package"""
     pl, cfg, pkgs = init(cwd, package, verbose)
     pl.enforce_version_consistency()
-    pl.install(sorted(pkgs), include_dev=dev, editable=editable)
+    pl.install(sorted(pkgs), include_dev=dev)
 
 
 @click.command()

--- a/pbt/diff.py
+++ b/pbt/diff.py
@@ -16,8 +16,8 @@ from pbt.package.manager.manager import PkgManager
 from pbt.package.package import Package
 
 # file size limit
-SOFT_SIZE_LIMIT = (1024 ** 2) * 1  # 1MB
-HARD_SIZE_LIMIT = (1024 ** 2) * 100  # 100MBs
+SOFT_SIZE_LIMIT = (1024**2) * 1  # 1MB
+HARD_SIZE_LIMIT = (1024**2) * 100  # 100MBs
 DIFF_DB_CACHE = {}
 
 
@@ -187,14 +187,14 @@ def format_size(n_bytes: int) -> str:
     if n_bytes < 1024:
         size = n_bytes
         unit = "Bs"
-    elif n_bytes >= 1024 and n_bytes < (1024 ** 2):
+    elif n_bytes >= 1024 and n_bytes < (1024**2):
         size = round(n_bytes / 1024, 2)
         unit = "KBs"
-    elif n_bytes >= (1024 ** 2) and n_bytes < (1024 ** 3):
-        size = round(n_bytes / (1024 ** 2), 2)
+    elif n_bytes >= (1024**2) and n_bytes < (1024**3):
+        size = round(n_bytes / (1024**2), 2)
         unit = "MBs"
     else:
-        assert n_bytes >= (1024 ** 3)
-        size = round(n_bytes / (1024 ** 3), 2)
+        assert n_bytes >= (1024**3)
+        size = round(n_bytes / (1024**3), 2)
         unit = "GBs"
     return f"{size}{unit}"

--- a/pbt/package/manager/manager.py
+++ b/pbt/package/manager/manager.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Literal, Optional, Set, Tuple, Union
 
 import semver
 from pbt.config import PBTConfig
-from pbt.misc import cache_method
+from pbt.misc import cache_func, cache_method
 from pbt.package.package import DepConstraint, DepConstraints, Package, VersionSpec
 
 
@@ -282,9 +282,10 @@ class PkgManager(ABC):
         """
         return self.parse_version_spec(version_spec).is_version_compatible(version)
 
-    @cache_method()
+    @classmethod
+    @cache_func()
     def parse_version_spec(
-        self,
+        cls,
         rule: str,
     ) -> VersionSpec:
         """Parse the given version rule to get lowerbound and upperbound (exclusive)
@@ -308,7 +309,7 @@ class PkgManager(ABC):
         if op1 == "":
             op1 = "=="
 
-        lowerbound = self.parse_version(version1)
+        lowerbound = cls.parse_version(version1)
         if op1 == "^":
             assert version2 is None
             # special case for 0 following the nodejs way (I can't believe why)
@@ -349,7 +350,7 @@ class PkgManager(ABC):
                 is_upperbound_inclusive=True,
             )
         else:
-            upperbound = self.parse_version(version2) if version2 is not None else None
+            upperbound = cls.parse_version(version2) if version2 is not None else None
             if op1 == "<" or op1 == "<=":
                 op1, op2 = op2, op1
                 lowerbound, upperbound = upperbound, lowerbound
@@ -379,8 +380,9 @@ class PkgManager(ABC):
         groups = m.groups()
         return f"{groups[0]}{str(version)}"
 
-    @cache_method()
-    def parse_version(self, version: str) -> semver.VersionInfo:
+    @classmethod
+    @cache_func()
+    def parse_version(cls, version: str) -> semver.VersionInfo:
         m = re.match(
             r"^(?P<major>\d+)(?P<minor>\.\d+)?(?P<patch>\.\d+)?(?P<rest>[^\d].*)?$",
             version,

--- a/pbt/package/manager/poetry.py
+++ b/pbt/package/manager/poetry.py
@@ -171,40 +171,39 @@ class Poetry(Pep518PkgManager):
                 f.write(dumps(doc))
             return
 
-        with open(poetry_file, "r") as f:
-            doc = cast(Any, loads(f.read()))
-            is_modified = False
+        doc = self.parse_pyproject(poetry_file)
+        is_modified = False
 
-            if pkg.name != doc["tool"]["poetry"]["name"]:
-                doc["tool"]["poetry"]["name"] = pkg.name
-                is_modified = True
+        if pkg.name != doc["tool"]["poetry"]["name"]:
+            doc["tool"]["poetry"]["name"] = pkg.name
+            is_modified = True
 
-            if pkg.version != doc["tool"]["poetry"]["version"]:
-                doc["tool"]["poetry"]["version"] = pkg.version
-                is_modified = True
+        if pkg.version != doc["tool"]["poetry"]["version"]:
+            doc["tool"]["poetry"]["version"] = pkg.version
+            is_modified = True
 
-            for dependencies, corr_key in [
-                (pkg.dependencies, "dependencies"),
-                (pkg.dev_dependencies, "dev-dependencies"),
-            ]:
-                dependencies: Dict[str, DepConstraints]
-                for dep, specs in dependencies.items():
-                    is_dep_modified = False
-                    if dep not in doc["tool"]["poetry"][corr_key]:
+        for dependencies, corr_key in [
+            (pkg.dependencies, "dependencies"),
+            (pkg.dev_dependencies, "dev-dependencies"),
+        ]:
+            dependencies: Dict[str, DepConstraints]
+            for dep, specs in dependencies.items():
+                is_dep_modified = False
+                if dep not in doc["tool"]["poetry"][corr_key]:
+                    is_dep_modified = True
+                else:
+                    other_vers = doc["tool"]["poetry"][corr_key][dep]
+                    if not isinstance(other_vers, list):
+                        other_vers = [other_vers]
+                    other_specs = [self.parse_dep_spec(v) for v in other_vers]
+                    if specs != other_specs:
                         is_dep_modified = True
-                    else:
-                        other_vers = doc["tool"]["poetry"][corr_key][dep]
-                        if not isinstance(other_vers, list):
-                            other_vers = [other_vers]
-                        other_specs = [self.parse_dep_spec(v) for v in other_vers]
-                        if specs != other_specs:
-                            is_dep_modified = True
 
-                    if is_dep_modified:
-                        doc["tool"]["poetry"][corr_key][dep] = self.serialize_dep_specs(
-                            specs
-                        )
-                        is_modified = True
+                if is_dep_modified:
+                    doc["tool"]["poetry"][corr_key][dep] = self.serialize_dep_specs(
+                        specs
+                    )
+                    is_modified = True
 
         if is_modified:
             success = False
@@ -215,6 +214,7 @@ class Poetry(Pep518PkgManager):
             try:
                 with open(poetry_file, "w") as f:
                     f.write(dumps(doc))
+                del self.cache_pyprojects[str(poetry_file.absolute())]
                 success = True
             finally:
                 if not success:

--- a/pbt/package/manager/python.py
+++ b/pbt/package/manager/python.py
@@ -1,0 +1,300 @@
+from abc import abstractmethod
+from contextlib import contextmanager
+import glob
+import os
+from pathlib import Path
+import shutil
+from typing import Dict, List, Literal, Optional, Union, cast
+
+from loguru import logger
+from pbt.config import PBTConfig
+from pbt.misc import cache_method, exec
+from pbt.package.manager.manager import PkgManager, build_cache
+from pbt.package.package import DepConstraints, Package, PackageType
+from tomlkit.api import loads
+from pbt.diff import Diff, diff_db
+
+
+class PythonPkgManager(PkgManager):
+    """Package Managers for Python should inherit this class."""
+
+    def __init__(self, cfg: PBTConfig, pkg_type: PackageType):
+        super().__init__(cfg)
+        self.managers: Dict[PackageType, PkgManager] = {pkg_type: self}
+        self.fixed_version_pkgs = {"python"}
+        self.passthrough_envs = ["PATH", "CC", "CXX"]
+
+    def set_package_managers(self, managers: Dict[PackageType, PkgManager]):
+        """Set all package managers, which will be used to retrieve correct package manager
+        for a particular python package.
+        """
+        self.managers = managers
+
+    def get_fixed_version_pkgs(self):
+        return self.fixed_version_pkgs
+
+    def compute_pkg_hash(self, pkg: Package, target: Optional[str] = None) -> str:
+        """Compute hash of the content of the package"""
+        # build the package in release mode
+        self.build(pkg, release=True, clean_dist=False)
+
+        # obtain the hash of the package
+        whl_path = self.wheel_path(pkg, target)
+        assert whl_path is not None, whl_path
+        output = exec(["pip", "hash", whl_path])[1]
+        output = output[output.find("--hash=") + len("--hash=") :]
+        assert output.startswith("sha256:")
+        return output[len("sha256:") :]
+
+    def clean(self, package: Package):
+        """Remove previously installed dependencies and the environment where the package is installed, for a freshly start.
+        In addition, this also cleans built artifacts.
+
+        Args:
+            package: The package to clean
+        """
+        path = (package.location / self.cfg.python_virtualenvs_path).absolute()
+        if path.exists():
+            shutil.rmtree(path)
+        for eggdir in glob.glob(str(package.location / "*.egg-info")):
+            shutil.rmtree(eggdir)
+        shutil.rmtree(package.location / self.cfg.distribution_dir, ignore_errors=True)
+
+    @cache_method()
+    def venv_path(self, name: str, dir: Path) -> Path:
+        """Get virtual environment path of the package, create it if doesn't exist.
+
+        For a package manager that manages virtualenvs in different location, it should override this function.
+
+        Arguments:
+            name: name of the package
+            dir: directory of the package
+        """
+        if not self.is_package_directory(dir):
+            raise ValueError(
+                f"{dir} seems to not contain any Python package. This won't return the right path. Please report this issue."
+            )
+
+        path = (dir / self.cfg.python_virtualenvs_path).absolute()
+        if not path.exists():
+            exec(f"{self.cfg.get_python_path()} -m venv {path}", env=["PATH"])
+
+        if not path.exists():
+            raise Exception(f"Environment path {path} doesn't exist")
+        return Path(path)
+
+    def tar_path(self, pkg: Package) -> Optional[Path]:
+        tar_file = pkg.location / "dist" / f"{pkg.name}-{pkg.version}.tar.gz"
+        if tar_file.exists():
+            return tar_file
+        return None
+
+    def wheel_path(
+        self,
+        pkg: Package,
+        target: Optional[str] = None,
+    ) -> Optional[Path]:
+        dist_dir = self.cfg.distribution_dir
+        if target is None:
+            whl_files = list((pkg.location / dist_dir).glob(f"{pkg.name}*.whl"))
+            if len(whl_files) == 0:
+                return None
+            if len(whl_files) > 1:
+                whl_files = list(
+                    (pkg.location / dist_dir).glob(f"{pkg.name}-{pkg.version}*.whl")
+                )
+                if len(whl_files) != 1:
+                    raise Exception(
+                        "Multiple wheels found at: {}".format(
+                            (pkg.location / dist_dir).absolute()
+                        )
+                    )
+
+            return whl_files[0]
+
+        whl_file = (
+            pkg.location
+            / dist_dir
+            / f"{pkg.name.replace('-', '_')}-{pkg.version}-{target}.whl"
+        )
+        if whl_file.exists():
+            return whl_file
+        return None
+
+    def pip_path(self, pkg: Package) -> Path:
+        """Get Pip executable from the virtual environment of the package."""
+        return self.venv_path(pkg.name, pkg.location) / "bin/pip"
+
+    def python_path(self, pkg: Package) -> Path:
+        """Get Python executable from the virtual environment of the package."""
+        return self.venv_path(pkg.name, pkg.location) / "bin/python"
+
+    def build(
+        self,
+        pkg: Package,
+        skip_deps: Optional[List[str]] = None,
+        additional_deps: Optional[Dict[str, DepConstraints]] = None,
+        release: bool = True,
+        clean_dist: bool = True,
+    ):
+        """Build the package. Support ignoring some dependencies to avoid installing and solving
+        dependencies multiple times (not in the super interface as compiled languages will complain).
+        """
+        with build_cache() as built_pkgs:
+            skip_deps = skip_deps or []
+            additional_deps = additional_deps or {}
+
+            build_ident = (pkg.name, pkg.version)
+            build_opts = (tuple(skip_deps), tuple(sorted(additional_deps.keys())))
+            if built_pkgs.get(build_ident, None) == build_opts:
+                return
+
+            with diff_db(pkg, self.cfg) as db:
+                with self.change_dependencies(pkg, skip_deps, additional_deps):
+                    diff = Diff.from_local(db, self, pkg)
+                    if (
+                        self.wheel_path(pkg) is not None
+                        and self.tar_path(pkg) is not None
+                    ):
+                        if not diff.is_modified(db):
+                            built_pkgs[build_ident] = build_opts
+                            return
+
+                    try:
+                        dist_dir = pkg.location / self.cfg.distribution_dir
+                        if clean_dist and (dist_dir).exists():
+                            shutil.rmtree(str(dist_dir))
+                        self._build_command(pkg, release)
+                    finally:
+                        diff.save(db)
+
+                    built_pkgs[build_ident] = build_opts
+
+    @abstractmethod
+    def install(
+        self,
+        package: Package,
+        include_dev: bool = False,
+        skip_deps: Optional[List[str]] = None,
+        additional_deps: Optional[Dict[str, DepConstraints]] = None,
+        virtualenv: Optional[Path] = None,
+    ):
+        """Install the package, assuming the the specification is updated. Note that if the package is phantom, only the dependencies are installed.
+
+        Note: don't expect this function will be able to find the local dependencies in the project
+        as the manager relies on a package registry. For local dependencies, add them to `skip_deps` anddd use `install_dependency` to install them
+        separately instead. Otherwise, you may get an error.
+
+        Args:
+            package: The package to install
+            include_dev: Whether to install dev dependencies
+            skip_deps: The dependencies to skip (usually the local ones we want to install in editable mode separately). This option is not guaranteed to compiled language
+            additional_deps: The additional dependencies to install
+            virtualenv: The virtual environment to install the package in. By default it is the virtual environment of the package
+        """
+        raise NotImplementedError()
+
+    def install_dependency(
+        self,
+        pkg: Package,
+        dependency: Package,
+        skip_dep_deps: Optional[List[str]] = None,
+    ):
+        assert dependency.name not in self.cfg.phantom_packages, dependency.name
+        assert self.managers is not None
+        dep_manager = self.managers[dependency.type]
+        assert isinstance(dep_manager, PythonPkgManager)
+
+        dep_manager.install(
+            dependency,
+            skip_deps=skip_dep_deps or [],
+            virtualenv=self.venv_path(pkg.name, pkg.location),
+        )
+
+    def publish(self, pkg: Package):
+        self.build(pkg, release=True)
+        exec("twine upload --skip-existing dist/*", cwd=pkg.location, env=["PATH"])
+
+    def get_virtualenv_environment_variables(self, virtualenv: Path) -> dict:
+        return {
+            "VIRTUAL_ENV": str(virtualenv),
+            "PATH": str(virtualenv / "bin") + os.pathsep + os.environ.get("PATH", ""),
+        }
+
+    @contextmanager  # type: ignore
+    @abstractmethod
+    def change_dependencies(
+        self,
+        pkg: Package,
+        skip_deps: List[str],
+        additional_deps: Dict[str, DepConstraints],
+        disable: bool = False,
+    ):
+        """Temporary change the dependencies of the package.
+
+        When skip_deps and additional_deps are both empty, this is a no-op.
+
+        Args:
+            pkg: The package to mask
+            skip_deps: The dependencies to skip
+            additional_deps: Additional dependencies to add
+            disable: Whether to manually disable the mask or not
+        """
+        pass
+
+    @abstractmethod
+    def _build_command(self, pkg: Package, release: bool):
+        """Run the build command for the package.
+
+        Arguments:
+            pkg: The package to build
+            release: whether to build in release mode
+        """
+        pass
+
+
+class Pep518PkgManager(PythonPkgManager):
+    """A package manager for Python packages that use PEP 518 (pyproject.toml)
+
+    Arguments:
+        cfg: pbt's configuration
+        backend: name of the building backend
+    """
+
+    def __init__(self, cfg: PBTConfig, pkg_type: PackageType, backend: str):
+        super().__init__(cfg, pkg_type)
+        self.backend = backend
+
+        self.cache_pyprojects = {}
+
+    def glob_query(self, root: Path) -> str:
+        return str(root.absolute() / "**/pyproject.toml")
+
+    def is_package_directory(self, dir: Path) -> bool:
+        if not (dir / "pyproject.toml").exists():
+            return False
+
+        return (
+            self.parse_pyproject(dir / "pyproject.toml")["build-system"][
+                "build-backend"
+            ]
+            == self.backend
+        )
+
+    def parse_pyproject(self, pyproject_file: Path) -> dict:
+        """Parse project metadata from the directory.
+
+        Arguments:
+            pyproject_file: path to the pyproject.toml file
+
+        Returns: dict, force the type to dictionary to silence the annoying type checker due to tomlkit
+        """
+        infile = str(pyproject_file.absolute())
+        if infile not in self.cache_pyprojects:
+            try:
+                with open(infile, "r") as f:
+                    self.cache_pyprojects[infile] = cast(dict, loads(f.read()))
+            except:
+                logger.error("Inavlid TOML file: {}", infile)
+                raise
+        return self.cache_pyprojects[infile]

--- a/pbt/package/pipeline.py
+++ b/pbt/package/pipeline.py
@@ -159,7 +159,7 @@ class BTPipeline:
                     and (
                         dep.name in pkg.dependencies or dep.name in pkg.dev_dependencies
                     )
-                    and (dep.name not in self.cfg.skip_building_packages)
+                    and (dep.name not in self.cfg.use_prebuilt_binaries)
                 ]
                 additional_deps = {
                     dep.name: next(iter(dep.invert_dependencies.values()))

--- a/pbt/package/pipeline.py
+++ b/pbt/package/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from loguru import logger
+from pbt.config import PBTConfig
 from pbt.diff import RemoteDiff
 from pbt.package.graph import PkgGraph, ThirdPartyPackage
 from pbt.package.manager.manager import PkgManager, build_cache
@@ -29,8 +30,9 @@ class VersionConsistent(enum.Enum):
 
 
 class BTPipeline:
-    def __init__(self, root: Path, managers: Dict[PackageType, PkgManager]) -> None:
-        self.root = root
+    def __init__(self, cfg: PBTConfig, managers: Dict[PackageType, PkgManager]) -> None:
+        self.root = cfg.cwd
+        self.cfg = cfg
         self.managers = managers
         self.graph = PkgGraph()
         self.pkgs: Dict[str, Package] = {}
@@ -157,6 +159,7 @@ class BTPipeline:
                     and (
                         dep.name in pkg.dependencies or dep.name in pkg.dev_dependencies
                     )
+                    and (dep.name not in self.cfg.skip_building_packages)
                 ]
                 additional_deps = {
                     dep.name: next(iter(dep.invert_dependencies.values()))

--- a/pbt/package/pipeline.py
+++ b/pbt/package/pipeline.py
@@ -135,13 +135,12 @@ class BTPipeline:
         self,
         pkg_names: List[str],
         include_dev: bool = False,
-        editable: bool = False,
     ):
         """Install packages
 
         Args:
             pkg_names: name of packages to install
-            editable: whether to install those packages in editable mode
+            include_dev: whether to install development dependencies
         """
         pkgs = [self.pkgs[name] for name in pkg_names]
 
@@ -173,7 +172,6 @@ class BTPipeline:
                     include_dev=include_dev,
                     skip_deps=skip_deps,
                     additional_deps=additional_deps,
-                    editable=editable,
                 )
 
                 for dep in deps:
@@ -183,7 +181,7 @@ class BTPipeline:
                             dep.dev_dependencies.keys()
                         )
                         manager.install_dependency(
-                            pkg, dep, editable=editable, skip_dep_deps=skip_dep_deps
+                            pkg, dep, skip_dep_deps=skip_dep_deps
                         )
 
     def publish(self, pkg_names: List[str], registries: Dict[PackageType, PkgRegistry]):

--- a/pbt/package/pipeline.py
+++ b/pbt/package/pipeline.py
@@ -170,10 +170,10 @@ class BTPipeline:
                 logger.info("Installing package: {}", pkg.name)
                 manager.install(
                     pkg,
-                    editable=editable,
                     include_dev=include_dev,
                     skip_deps=skip_deps,
                     additional_deps=additional_deps,
+                    editable=editable,
                 )
 
                 for dep in deps:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,638 @@
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "black"
+version = "22.6.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "certifi"
+version = "2022.6.15"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "coverage"
+version = "6.4.1"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "lbry-rocksdb-optimized"
+version = "0.8.1"
+description = "Python bindings for RocksDB"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.extras]
+doc = ["sphinx-rtd-theme", "sphinx"]
+
+[[package]]
+name = "loguru"
+version = "0.6.0"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["colorama (>=0.3.4)", "docutils (==0.16)", "flake8 (>=3.7.7)", "tox (>=3.9.0)", "pytest (>=4.6.2)", "pytest-cov (>=2.7.1)", "black (>=19.10b0)", "isort (>=5.1.1)", "Sphinx (>=4.1.1)", "sphinx-autobuild (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)"]
+
+[[package]]
+name = "maturin"
+version = "0.12.20"
+description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+zig = ["ziglang (>=0.9.0,<0.10.0)"]
+patchelf = ["patchelf"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "networkx"
+version = "2.8.4"
+description = "Python package for creating and manipulating graphs and networks"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.extras]
+default = ["numpy (>=1.19)", "scipy (>=1.8)", "matplotlib (>=3.4)", "pandas (>=1.3)"]
+developer = ["pre-commit (>=2.19)", "mypy (>=0.960)"]
+doc = ["sphinx (>=5)", "pydata-sphinx-theme (>=0.9)", "sphinx-gallery (>=0.10)", "numpydoc (>=1.4)", "pillow (>=9.1)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
+extra = ["lxml (>=4.6)", "pygraphviz (>=1.9)", "pydot (>=1.4.2)", "sympy (>=1.10)"]
+test = ["pytest (>=7.1)", "pytest-cov (>=3.0)", "codecov (>=2.1)"]
+
+[[package]]
+name = "orjson"
+version = "3.7.5"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.2"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.8.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "semver"
+version = "2.13.0"
+description = "Python helper for Semantic Versioning (http://semver.org/)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "tomlkit"
+version = "0.7.2"
+description = "Style preserving TOML library"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "typing-extensions"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "642246fffe8611fb846639be1dd42348b975831fa5f0d8de3494c4378f059142"
+
+[metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+]
+certifi = [
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+coverage = [
+    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
+    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
+    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
+    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
+    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
+    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
+    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
+    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
+    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
+    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
+    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
+    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+lbry-rocksdb-optimized = [
+    {file = "lbry_rocksdb_optimized-0.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:63deffdbadd292bea5d0a186c7b484a08e2f56d510d9e972ce33d2c203bd47ec"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:589afcfabee2b99c5f2fea67ae5796d0a8ad50cd477c4dc3c2ca8bcf4569e077"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3abc79df199165df4dc8bd3d7fb1a1b33d374f183f20a283f865fcf146283285"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:67946d1c8cdf4ea492f3196a364dd6df4bfa443b0750645b98fdaeebcf848ca2"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d82c2ad55b51e8d1d26c09140f69ebcb541c27cb4bdd63c857754e5b7a2c44b"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:f6e843707c36f3b4c5078b09b2937900e59c554aafc93b48c79a6fb68eaddeec"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp38-cp38-macosx_10_14_arm64.whl", hash = "sha256:0c7a98dcdb9df1565780344d903ca82f7a9da530f7276d21ad414ddfcdaf435c"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ccdbc8696f14f760566ef2bbc44098a74759e51a5da38a3c27ad2ca28632596f"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:85c460741aad1393949e9779fd3b76dde094cb2b925d9351edfef76240799a60"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31e3477b4e4dd12909c8dc60e881fd24c6349b283b98c1c73d3b313a52fa0cf8"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:f396c2af130a740a6ffdde68079ed6d03425b7751697f3e4ea67a0d193cf3f4a"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f581787af5a5308f90ea91be30ec52404da3bf1601d6da1d461238cbfe209797"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:66e44188f2ed425810e056f55f4c8a445fd67a05b03033b3443d7d19ffdab8d9"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:5a91c29ff4dbbee262aa4f455e271f6bcb6c98ff8b28566dd30b4b87a981b441"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0742c85d96ade0ce89743619e8f8c77a93447a5c701133fa60c093fd424d57e8"},
+    {file = "lbry_rocksdb_optimized-0.8.1-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:46262dcee200d21498cec54e03b3816cb751dee4d774803184b874d9883c4199"},
+    {file = "lbry_rocksdb_optimized-0.8.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8fa6ad0ae4e261206bbd7b415c633ad28b4416f7620c11e6f8e24bd909d5aabc"},
+    {file = "lbry_rocksdb_optimized-0.8.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65e058b24fd5addb1152257e44b043719f3fca1e72e99c34e6ac2df34a7af57a"},
+    {file = "lbry_rocksdb_optimized-0.8.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3b9e57a5a3a440cef08a0580f87589a90db131eb4609e30d9d15c7b921e9a468"},
+]
+loguru = [
+    {file = "loguru-0.6.0-py3-none-any.whl", hash = "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3"},
+    {file = "loguru-0.6.0.tar.gz", hash = "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c"},
+]
+maturin = [
+    {file = "maturin-0.12.20-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:d4ced017aa26dd88ce228a21e8f049b7c6f9b40c873e90fb7bec60f49b93fe55"},
+    {file = "maturin-0.12.20-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:83e7b4bcb3f30523bd951d858fc6508fef85e33840e3c8947a0b36c3dd73532a"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:3ea8b7976d2ed35ca6d799ead19667afef9a50f806a7f090721cea7513cb6166"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:ac3b6ae80adfd2ddb581d78ac695abfeb1e222bf122f0f8cb04ab2bae47046b1"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:79a26abbbbdb78958894837663e18e39c36635bcc0674ed40217b3519c488115"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:6e2e1cd499599e70db72512fe1bf03b6e362af572051c8a8a255282c17800cfb"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:7ee333b400d0ac6055c89bd82817e7f1360502f9f5089a196470e5f063af6afc"},
+    {file = "maturin-0.12.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41fc10a85f9e32bbf301004179d96f316f41dfebb01770c19420fe783acd6612"},
+    {file = "maturin-0.12.20-py3-none-win32.whl", hash = "sha256:cb2a82d019585f4ca5a49bf56cded757a13e960617b334d601b837b78f84b960"},
+    {file = "maturin-0.12.20-py3-none-win_amd64.whl", hash = "sha256:b170594180ddb6144b943a02f57b649deb7d580251c14f2f41546d5e0c876e04"},
+    {file = "maturin-0.12.20-py3-none-win_arm64.whl", hash = "sha256:b6b671c50dfa01094c9327ddb713ea3d4a24034552e898479503eb0e924b12ef"},
+    {file = "maturin-0.12.20.tar.gz", hash = "sha256:62ef15831f14330aa426c2ccc475c5b8d473bb52731e478e0cb9ab37e137d758"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+networkx = [
+    {file = "networkx-2.8.4-py3-none-any.whl", hash = "sha256:6933b9b3174a0bdf03c911bb4a1ee43a86ce3edeb813e37e1d4c553b3f4a2c4f"},
+    {file = "networkx-2.8.4.tar.gz", hash = "sha256:5e53f027c0d567cf1f884dbb283224df525644e43afd1145d64c9d88a3584762"},
+]
+orjson = [
+    {file = "orjson-3.7.5-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:bfa8d3412d1f73d8cceb5ce96cfb50ba897d3bc9acc5e2e13240a94a75fcdbdc"},
+    {file = "orjson-3.7.5-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:fad043bd582ad4e9177d4d32173c3d388a0ab5a71ab51ce5a01aaee8ddf338d4"},
+    {file = "orjson-3.7.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e481c8511bab48dbc2db7389944fa85b95fabceec6693fa5f0876cea4910cf73"},
+    {file = "orjson-3.7.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3caade3cea3003263cb87f2c193e9dcdc82e83ae936631a494f980f677fc8a46"},
+    {file = "orjson-3.7.5-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:928e1120057cea1f9a931740c840e0faeaf019ed3df767c499450057c3f878b7"},
+    {file = "orjson-3.7.5-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d849b269a55564821b64f3e781b2e7746fb5c39f28bfe27cf6330a43eb89ed2b"},
+    {file = "orjson-3.7.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c124fffb72a9393f21ba27519e8a619d473b6b94c591045a8a206344425e2093"},
+    {file = "orjson-3.7.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8d0983147121e9e87dddda7997c08331fdf0b26fad22a11e11bfc333169bb305"},
+    {file = "orjson-3.7.5-cp310-none-win_amd64.whl", hash = "sha256:65a8d18fdaee45807b8bd7ead2898293d23d4d766cf42d63022a40758591a707"},
+    {file = "orjson-3.7.5-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:fcdef342b0a810a15a559208b24f13198ce2252a441868e0265bdb82ba85b1eb"},
+    {file = "orjson-3.7.5-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ad035d250d438cfd2a1d38dd54d5b800ca67290a89e14b5345c55b2fb0e186e0"},
+    {file = "orjson-3.7.5-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7316ea00623121178139240fddc0bc2de3f730b0d93081c7f5c6780eea75417b"},
+    {file = "orjson-3.7.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd46103e9d60a87e9497ccb72b6a32d0f12586d0abcd1a5a5a375bacad3b5f50"},
+    {file = "orjson-3.7.5-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:78e23d0491a54d3a3cf658ee7e62134d96436850bbc6eb199e3a2514444de785"},
+    {file = "orjson-3.7.5-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:dca21c76552b0b539b38121ffd397e129af6b2b0d9c586a96e33652691d3e87d"},
+    {file = "orjson-3.7.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:376248b40b7c917c563311af1ce511f9e01c7e982bdf5c01d1287f7d9672cf95"},
+    {file = "orjson-3.7.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4b0ab07bdc34fa54c56ab385926aadb89b6106498ed762297418189d97cc6c43"},
+    {file = "orjson-3.7.5-cp37-none-win_amd64.whl", hash = "sha256:0893ff1e7952267b7e54062b9ceee670da81e52825d81f04473a40a88239200c"},
+    {file = "orjson-3.7.5-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:d89e26508e50551acd97c96780be6ba7c755997985d5143c9222daab014f1bc2"},
+    {file = "orjson-3.7.5-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:314ae3957a096baf0d58f9650e062bc6d1a3e554f7c8847b19cb9846134bcf62"},
+    {file = "orjson-3.7.5-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:16acac2ba4ab747acc1a8b3c72487d0a88031925f5a8662fa2dc25d812edaf10"},
+    {file = "orjson-3.7.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:383ee9124f585cf75fc5fdfa01497fe89c0667b1d72c22bed2a07904bfb3d09d"},
+    {file = "orjson-3.7.5-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:88a8be38e9be7cbc1227e3b4d946b5e9d3586149f92f5b78ce7a85b1c247e00c"},
+    {file = "orjson-3.7.5-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:57a0e86d59c61b8cf91d84a9959b4c7f903d1243cee9b3d269aa5ea65ce2686f"},
+    {file = "orjson-3.7.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:04468b96014ff953a0bc0db8ae89de4df33b5008cfa25de200deb7483eebdaa8"},
+    {file = "orjson-3.7.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3202dafd6d54950b89eb872a74152f74440bc010bd5675eac39a31f940c5c545"},
+    {file = "orjson-3.7.5-cp38-none-win_amd64.whl", hash = "sha256:c63bbea3fe5087b4586cd94393ecc368c7cd62018c9470e0175a483ebbcf2a8c"},
+    {file = "orjson-3.7.5-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:828f4767fda30faeed7adaa2d004b400fb55d5ca3b8127ee053e9d62addadc16"},
+    {file = "orjson-3.7.5-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9be3b6411a6ca75aa255f1d0139d36bdce80159738932d7311abaa82e28f2021"},
+    {file = "orjson-3.7.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed1ff20a4ee6571e2a4a432e2d4a6ad82cbc6a698acf860b5ceb066fdae3b859"},
+    {file = "orjson-3.7.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e19f12762ef7693999197be1860df204589f4e907d3a7c76ad6aa764ee94877"},
+    {file = "orjson-3.7.5-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:5e3c1373b069fe10cb5e84c1df12a89e1a40b04d95af1ea0e113ce9dc455db53"},
+    {file = "orjson-3.7.5-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:215102b89fec7e3f8a760a6667fee3ec9fd3f1e2a89293265141e884c5a239f5"},
+    {file = "orjson-3.7.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a4a221479e6b52305ce572e9a8403bbc47815ef1ed1c41d378f4de8efaa7b57c"},
+    {file = "orjson-3.7.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:76e91ea4c73a9e28924bb2e1f8ebd29b969b7b3d4b6c30e17b408c36d5f79f46"},
+    {file = "orjson-3.7.5-cp39-none-win_amd64.whl", hash = "sha256:d444bb261b6ce58ab7c3998cbb72a0ca2b7b4d1e120e4e22b4d2c4a927960ca6"},
+    {file = "orjson-3.7.5.tar.gz", hash = "sha256:47c9d2b3f993b630b1efa58ad128b5d8a61cd7cd5c0cec8dad043a1ab9d02866"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.8.1.tar.gz", hash = "sha256:2c6d756d5d3bf98e2e80797a959ca7f81f479e7d1f5f571611b0fdd6d1745240"},
+    {file = "pytest_mock-3.8.1-py3-none-any.whl", hash = "sha256:d989f11ca4a84479e288b0cd1e6769d6ad0d3d7743dcc75e460d1416a5f2135a"},
+]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+semver = [
+    {file = "semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4"},
+    {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
+    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]
+win32-setctime = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pab"
-version = "2.4.0"
+version = "2.5.0"
 description = "A build tool for multi-projects that leverages package registries (pypi, npmjs, etc.)"
 authors = ["Binh Vu <binh@toan2.com>"]
 homepage = "https://github.com/binh-vu/pbt"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,7 @@ def make_pyrepo(cwd: Path, libs: List[Package], submodules: List[Package]):
     cache_dir = cwd / ".cache"
     cache_dir.mkdir(parents=True)
 
-    cfg = PBTConfig(cwd, cache_dir, ignore_packages=set(), phantom_packages=set())
+    cfg = PBTConfig(cwd, cache_dir)
 
     # setup project directory
     tree = {}
@@ -231,9 +231,7 @@ def make_pyrepo(cwd: Path, libs: List[Package], submodules: List[Package]):
         }
     setup_dir(tree, cwd)
 
-    managers: Dict[PackageType, PkgManager] = {}
-    managers[PackageType.Poetry] = Poetry(cfg, managers)
-    poetry = cast(Poetry, managers[PackageType.Poetry])
+    poetry = Poetry(cfg)
 
     for lib in libs:
         poetry.save(lib)

--- a/tests/package/manager/test_manager.py
+++ b/tests/package/manager/test_manager.py
@@ -22,13 +22,14 @@ def test_build_cache():
 
 
 def test_parse_version_spec():
-    vs = PkgManager.parse_version_spec(">=2.0.0-alpha.15")
+    manager = PkgManager(None)
+    vs = manager.parse_version_spec(">=2.0.0-alpha.15")
     assert vs == VersionSpec(VersionInfo.parse("2.0.0-alpha.15"), None, True, False)
 
-    vs = PkgManager.parse_version_spec(">2.0.0-alpha.15")
+    vs = manager.parse_version_spec(">2.0.0-alpha.15")
     assert vs == VersionSpec(VersionInfo.parse("2.0.0-alpha.15"), None, False, False)
 
-    vs = PkgManager.parse_version_spec(">2.0.0-alpha.15, <=5.2.1")
+    vs = manager.parse_version_spec(">2.0.0-alpha.15, <=5.2.1")
     assert vs == VersionSpec(
         VersionInfo.parse("2.0.0-alpha.15"), VersionInfo.parse("5.2.1"), False, True
     )

--- a/tests/package/manager/test_manager.py
+++ b/tests/package/manager/test_manager.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+from pbt.config import PBTConfig
 from pbt.package.manager.manager import PkgManager, build_cache
+from pbt.package.manager.poetry import Poetry
 from pbt.package.package import VersionSpec
 from semver import VersionInfo
 
@@ -22,14 +25,13 @@ def test_build_cache():
 
 
 def test_parse_version_spec():
-    manager = PkgManager(None)
-    vs = manager.parse_version_spec(">=2.0.0-alpha.15")
+    vs = PkgManager.parse_version_spec(">=2.0.0-alpha.15")
     assert vs == VersionSpec(VersionInfo.parse("2.0.0-alpha.15"), None, True, False)
 
-    vs = manager.parse_version_spec(">2.0.0-alpha.15")
+    vs = PkgManager.parse_version_spec(">2.0.0-alpha.15")
     assert vs == VersionSpec(VersionInfo.parse("2.0.0-alpha.15"), None, False, False)
 
-    vs = manager.parse_version_spec(">2.0.0-alpha.15, <=5.2.1")
+    vs = PkgManager.parse_version_spec(">2.0.0-alpha.15, <=5.2.1")
     assert vs == VersionSpec(
         VersionInfo.parse("2.0.0-alpha.15"), VersionInfo.parse("5.2.1"), False, True
     )

--- a/tests/package/test_pipeline.py
+++ b/tests/package/test_pipeline.py
@@ -15,7 +15,7 @@ def test_discover(repo1: Repo):
     assert pl.pkgs == repo1.packages
 
 
-def test_install(repo1: Repo):
+def test_python_install(repo1: Repo):
     lib0 = repo1.packages["lib0"]
     lib1 = repo1.packages["lib1"]
     lib2 = repo1.packages["lib2"]
@@ -27,39 +27,8 @@ def test_install(repo1: Repo):
     pl.discover()
 
     assert get_dependencies(poetry.pip_path(lib2)) == []
-    pl.install([lib2.name], editable=False)
-    assert get_dependencies(poetry.pip_path(lib2)) == [
-        PipFreezePkgInfo(name=lib0.name, editable=False, version="0.5.1"),
-        PipFreezePkgInfo(name=lib1.name, editable=False, version="0.2.1"),
-        PipFreezePkgInfo(name=lib2.name, editable=False, version="0.6.7"),
-    ]
+    pl.install([lib2.name])
 
-    assert exec(f"{python} -m {lib0.name}")[0] == lib0.name
-
-    # make some changes and get it build correctly
-    setup_dir({"lib0": {"__main__.py": "print('lib0 - update 1')"}}, lib0.location)
-    assert (
-        exec(f"{python} -m {lib0.name}")[0] == lib0.name
-    ), "Change should not be reflected immediately before we build again"
-
-    pl.install([lib2.name], editable=False)
-    # now we should see the changes
-    assert exec(f"{python} -m {lib0.name}")[0] == "lib0 - update 1"
-
-
-def test_install_editable(repo1: Repo):
-    lib0 = repo1.packages["lib0"]
-    lib1 = repo1.packages["lib1"]
-    lib2 = repo1.packages["lib2"]
-
-    poetry = repo1.poetry
-    python = poetry.python_path(lib2)
-
-    pl = BTPipeline(repo1.cfg.cwd, managers={PackageType.Poetry: poetry})
-    pl.discover()
-
-    assert get_dependencies(poetry.pip_path(lib2)) == []
-    pl.install([lib2.name], editable=True)
     assert get_dependencies(poetry.pip_path(lib2)) == [
         PipFreezePkgInfo(name=lib0.name, editable=True, version="0.5.1"),
         PipFreezePkgInfo(name=lib1.name, editable=True, version="0.2.1"),

--- a/tests/package/test_pipeline.py
+++ b/tests/package/test_pipeline.py
@@ -8,7 +8,7 @@ from pbt.misc import exec
 
 
 def test_discover(repo1: Repo):
-    pl = BTPipeline(repo1.cfg.cwd, managers={PackageType.Poetry: repo1.poetry})
+    pl = BTPipeline(repo1.cfg, managers={PackageType.Poetry: repo1.poetry})
 
     assert pl.pkgs == {}
     pl.discover()
@@ -23,7 +23,7 @@ def test_python_install(repo1: Repo):
     poetry = repo1.poetry
     python = poetry.python_path(lib2)
 
-    pl = BTPipeline(repo1.cfg.cwd, managers={PackageType.Poetry: poetry})
+    pl = BTPipeline(repo1.cfg, managers={PackageType.Poetry: poetry})
     pl.discover()
 
     assert get_dependencies(poetry.pip_path(lib2)) == []
@@ -48,7 +48,7 @@ def test_enforce_version_consistency(repo1: Repo):
     lib2 = repo1.packages["lib2"]
     lib3 = repo1.packages["lib3"]
 
-    pl = BTPipeline(repo1.cfg.cwd, managers={PackageType.Poetry: repo1.poetry})
+    pl = BTPipeline(repo1.cfg, managers={PackageType.Poetry: repo1.poetry})
 
     # first update doesn't change anything
     pl.discover()
@@ -111,7 +111,7 @@ def test_enforce_version_consistency(repo1: Repo):
 
 
 def test_publish(repo1: Repo, mockup_pypi: PkgRegistry, mocker: MockerFixture):
-    pl = BTPipeline(repo1.cfg.cwd, managers={PackageType.Poetry: repo1.poetry})
+    pl = BTPipeline(repo1.cfg, managers={PackageType.Poetry: repo1.poetry})
     registries = {PackageType.Poetry: mockup_pypi}
     pl.discover()
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,13 +21,9 @@ def test_exec():
         cfg = PBTConfig(
             cwd=tmpdir,
             cache_dir=tmpdir / ".cache",
-            ignore_packages=set(),
-            phantom_packages=set(),
         )
 
-        managers: Dict[PackageType, PkgManager] = {}
-        managers[PackageType.Poetry] = Poetry(cfg, managers)
-        poetry = cast(Poetry, managers[PackageType.Poetry])
+        poetry = Poetry(cfg)
 
         pkg = Package(
             name="test",


### PR DESCRIPTION
* Options to skip building some packages (i.e., rely on package registries to find an installable version)
* Choose the directory (default is the local `.venv` directory) for virtualenv in python
* Choose Python through `python_path` in configuration or `PBT_PYTHON` in environment variables.